### PR TITLE
Updated DX11 offset for patch 4.06

### DIFF
--- a/Offsets.xml
+++ b/Offsets.xml
@@ -8,11 +8,11 @@
     <FovMax>10C</FovMax>
   </DX9>
   <DX11>
-    <StructureAddress>1785EB0</StructureAddress>
+    <StructureAddress>1786EB0</StructureAddress>
     <ZoomCurrent>128</ZoomCurrent>
     <ZoomMax>130</ZoomMax>
     <FovCurrent>134</FovCurrent>
     <FovMax>13C</FovMax>
   </DX11>
-  <LastUpdate>2017-06-16 - patch 4.0 (DX11)</LastUpdate>
+  <LastUpdate>2017-08-10 - patch 4.06 (DX11)</LastUpdate>
 </Root>


### PR DESCRIPTION
Patch 4.06 broke this. Did my best following directions to find the value for DX11. Please verify this is my first time doing such a thing.

Edit: Figured out how to verify this. It works!