### PR TITLE
Added auto quit, align Default URL/Update Offset boxes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,6 @@ $RECYCLE.BIN/
 
 # Mac desktop service store files
 .DS_Store
+
+# Visual Studio working directory?
+/.vs

--- a/FFXIVZoomHack/Form1.Designer.cs
+++ b/FFXIVZoomHack/Form1.Designer.cs
@@ -28,6 +28,7 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             this._autoApplyCheckbox = new System.Windows.Forms.CheckBox();
             this._zoomSettingsBox = new System.Windows.Forms.GroupBox();
             this._fovUpDown = new System.Windows.Forms.NumericUpDown();
@@ -37,12 +38,14 @@
             this._fovLabel = new System.Windows.Forms.Label();
             this._zoomLabel = new System.Windows.Forms.Label();
             this._processListBox = new System.Windows.Forms.GroupBox();
+            this._autoQuitCheckbox = new System.Windows.Forms.CheckBox();
             this._gotoProcessButton = new System.Windows.Forms.Button();
             this.label1 = new System.Windows.Forms.Label();
             this._processList = new System.Windows.Forms.ComboBox();
             this._updateOffsetsTextbox = new System.Windows.Forms.TextBox();
             this._updateOffsetsButton = new System.Windows.Forms.Button();
             this._updateLocationDefault = new System.Windows.Forms.Button();
+            this.autoQuitTooltip = new System.Windows.Forms.ToolTip(this.components);
             this._zoomSettingsBox.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this._fovUpDown)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this._zoomUpDown)).BeginInit();
@@ -53,7 +56,7 @@
             // 
             this._autoApplyCheckbox.AutoSize = true;
             this._autoApplyCheckbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this._autoApplyCheckbox.Location = new System.Drawing.Point(6, 25);
+            this._autoApplyCheckbox.Location = new System.Drawing.Point(10, 25);
             this._autoApplyCheckbox.Name = "_autoApplyCheckbox";
             this._autoApplyCheckbox.Size = new System.Drawing.Size(219, 24);
             this._autoApplyCheckbox.TabIndex = 0;
@@ -171,6 +174,7 @@
             // 
             this._processListBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this._processListBox.Controls.Add(this._autoQuitCheckbox);
             this._processListBox.Controls.Add(this._gotoProcessButton);
             this._processListBox.Controls.Add(this.label1);
             this._processListBox.Controls.Add(this._processList);
@@ -182,6 +186,18 @@
             this._processListBox.TabIndex = 2;
             this._processListBox.TabStop = false;
             this._processListBox.Text = "Processes";
+            // 
+            // _autoQuitCheckbox
+            // 
+            this._autoQuitCheckbox.AutoSize = true;
+            this._autoQuitCheckbox.Location = new System.Drawing.Point(243, 25);
+            this._autoQuitCheckbox.Name = "_autoQuitCheckbox";
+            this._autoQuitCheckbox.Size = new System.Drawing.Size(217, 24);
+            this._autoQuitCheckbox.TabIndex = 11;
+            this._autoQuitCheckbox.Text = "Quit when processes close";
+            this.autoQuitTooltip.SetToolTip(this._autoQuitCheckbox, "Automatically close FFXIV Zoom Hack after \r\npreviously detected instances of FFXI" +
+        "V are closed");
+            this._autoQuitCheckbox.UseVisualStyleBackColor = true;
             // 
             // _gotoProcessButton
             // 
@@ -219,9 +235,9 @@
             // 
             // _updateOffsetsButton
             // 
-            this._updateOffsetsButton.Location = new System.Drawing.Point(404, 12);
+            this._updateOffsetsButton.Location = new System.Drawing.Point(404, 13);
             this._updateOffsetsButton.Name = "_updateOffsetsButton";
-            this._updateOffsetsButton.Size = new System.Drawing.Size(83, 43);
+            this._updateOffsetsButton.Size = new System.Drawing.Size(83, 42);
             this._updateOffsetsButton.TabIndex = 9;
             this._updateOffsetsButton.Text = "Update Offsets";
             this._updateOffsetsButton.UseVisualStyleBackColor = true;
@@ -229,11 +245,11 @@
             // 
             // _updateLocationDefault
             // 
-            this._updateLocationDefault.Location = new System.Drawing.Point(325, 14);
+            this._updateLocationDefault.Location = new System.Drawing.Point(325, 13);
             this._updateLocationDefault.Name = "_updateLocationDefault";
-            this._updateLocationDefault.Size = new System.Drawing.Size(75, 41);
+            this._updateLocationDefault.Size = new System.Drawing.Size(75, 42);
             this._updateLocationDefault.TabIndex = 10;
-            this._updateLocationDefault.Text = "Default";
+            this._updateLocationDefault.Text = "Default\r\nURL";
             this._updateLocationDefault.UseVisualStyleBackColor = true;
             this._updateLocationDefault.Click += new System.EventHandler(this._updateLocationDefault_Click);
             // 
@@ -266,6 +282,7 @@
         #endregion
 
         private System.Windows.Forms.CheckBox _autoApplyCheckbox;
+        private System.Windows.Forms.CheckBox _autoQuitCheckbox;
         private System.Windows.Forms.GroupBox _zoomSettingsBox;
         private System.Windows.Forms.GroupBox _processListBox;
         private System.Windows.Forms.Label _fovLabel;
@@ -280,6 +297,7 @@
         private System.Windows.Forms.TextBox _updateOffsetsTextbox;
         private System.Windows.Forms.Button _updateOffsetsButton;
         private System.Windows.Forms.Button _updateLocationDefault;
+        private System.Windows.Forms.ToolTip autoQuitTooltip;
     }
 }
 

--- a/FFXIVZoomHack/Form1.Designer.cs
+++ b/FFXIVZoomHack/Form1.Designer.cs
@@ -45,7 +45,7 @@
             this._updateOffsetsTextbox = new System.Windows.Forms.TextBox();
             this._updateOffsetsButton = new System.Windows.Forms.Button();
             this._updateLocationDefault = new System.Windows.Forms.Button();
-            this.autoQuitTooltip = new System.Windows.Forms.ToolTip(this.components);
+            this._autoQuitTooltip = new System.Windows.Forms.ToolTip(this.components);
             this._zoomSettingsBox.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this._fovUpDown)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this._zoomUpDown)).BeginInit();
@@ -195,7 +195,7 @@
             this._autoQuitCheckbox.Size = new System.Drawing.Size(217, 24);
             this._autoQuitCheckbox.TabIndex = 11;
             this._autoQuitCheckbox.Text = "Quit when processes close";
-            this.autoQuitTooltip.SetToolTip(this._autoQuitCheckbox, "Automatically close FFXIV Zoom Hack after \r\npreviously detected instances of FFXI" +
+            this._autoQuitTooltip.SetToolTip(this._autoQuitCheckbox, "Automatically close FFXIV Zoom Hack after \r\npreviously detected instances of FFXI" +
         "V are closed");
             this._autoQuitCheckbox.UseVisualStyleBackColor = true;
             // 
@@ -283,7 +283,7 @@
 
         private System.Windows.Forms.CheckBox _autoApplyCheckbox;
         private System.Windows.Forms.CheckBox _autoQuitCheckbox;
-        private System.Windows.Forms.ToolTip autoQuitTooltip;
+        private System.Windows.Forms.ToolTip _autoQuitTooltip;
         private System.Windows.Forms.GroupBox _zoomSettingsBox;
         private System.Windows.Forms.GroupBox _processListBox;
         private System.Windows.Forms.Label _fovLabel;

--- a/FFXIVZoomHack/Form1.Designer.cs
+++ b/FFXIVZoomHack/Form1.Designer.cs
@@ -283,6 +283,7 @@
 
         private System.Windows.Forms.CheckBox _autoApplyCheckbox;
         private System.Windows.Forms.CheckBox _autoQuitCheckbox;
+        private System.Windows.Forms.ToolTip autoQuitTooltip;
         private System.Windows.Forms.GroupBox _zoomSettingsBox;
         private System.Windows.Forms.GroupBox _processListBox;
         private System.Windows.Forms.Label _fovLabel;
@@ -297,7 +298,6 @@
         private System.Windows.Forms.TextBox _updateOffsetsTextbox;
         private System.Windows.Forms.Button _updateOffsetsButton;
         private System.Windows.Forms.Button _updateLocationDefault;
-        private System.Windows.Forms.ToolTip autoQuitTooltip;
     }
 }
 

--- a/FFXIVZoomHack/Form1.cs
+++ b/FFXIVZoomHack/Form1.cs
@@ -29,6 +29,9 @@ namespace FFXIVZoomHack
             _autoApplyCheckbox.Checked = Settings.AutoApply;
             _autoApplyCheckbox.CheckedChanged += AutoApplyCheckChanged;
 
+            _autoQuitCheckbox.Checked = Settings.AutoQuit;
+            _autoQuitCheckbox.CheckedChanged += AutoQuitCheckChanged;
+
             _zoomUpDown.Value = (decimal) Settings.DesiredZoom;
             _zoomUpDown.ValueChanged += NumberChanged;
             _fovUpDown.Value = (decimal) Settings.DesiredFov;
@@ -57,6 +60,7 @@ namespace FFXIVZoomHack
                         var activePids = Memory.GetPids()
                             .ToArray();
                         var knownPids = GetCurrentPids();
+
                         foreach (var pid in activePids.Except(knownPids))
                         {
                             _processList.Items.Add(pid);
@@ -84,6 +88,11 @@ namespace FFXIVZoomHack
                             {
                                 ApplyChanges(newPids);
                             }
+                        }
+
+                        if (activePids.Count() == 0 && knownPids.Count() > 0 && _autoQuitCheckbox.Checked == true)
+                        {
+                            Application.Exit();
                         }
                     });
             }
@@ -115,6 +124,16 @@ namespace FFXIVZoomHack
             Settings.AutoApply = !Settings.AutoApply;
             Settings.Save();
             if (Settings.AutoApply)
+            {
+                ApplyChanges();
+            }
+        }
+
+        private void AutoQuitCheckChanged(object sender, EventArgs e)
+        {
+            Settings.AutoQuit = !Settings.AutoQuit;
+            Settings.Save();
+            if (Settings.AutoQuit)
             {
                 ApplyChanges();
             }

--- a/FFXIVZoomHack/Form1.resx
+++ b/FFXIVZoomHack/Form1.resx
@@ -117,7 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="autoQuitTooltip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="_autoQuitTooltip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <metadata name="_autoQuitTooltip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
 </root>

--- a/FFXIVZoomHack/Form1.resx
+++ b/FFXIVZoomHack/Form1.resx
@@ -117,4 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="autoQuitTooltip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/FFXIVZoomHack/Settings.cs
+++ b/FFXIVZoomHack/Settings.cs
@@ -15,6 +15,7 @@ namespace FFXIVZoomHack
         private Settings()
         {
             AutoApply = true;
+            AutoQuit = false;
 
             DesiredZoom = 20;
             DesiredFov = 0.78f;
@@ -37,6 +38,7 @@ namespace FFXIVZoomHack
         }
 
         public bool AutoApply { get; set; }
+        public bool AutoQuit { get; set; }
         public float DesiredFov { get; set; }
         public float DesiredZoom { get; set; }
 
@@ -68,6 +70,9 @@ namespace FFXIVZoomHack
                     {
                         case "AutoApply":
                             settings.AutoApply = bool.Parse(element.Value);
+                            break;
+                        case "AutoQuit":
+                            settings.AutoQuit = bool.Parse(element.Value);
                             break;
                         case "DX9":
                             settings.DX9_StructureAddress = element.Element("StructureAddress")
@@ -159,6 +164,7 @@ namespace FFXIVZoomHack
                 yield break;
             }
             yield return new XElement("AutoApply", AutoApply.ToString(CultureInfo.InvariantCulture));
+            yield return new XElement("AutoQuit", AutoQuit.ToString(CultureInfo.InvariantCulture));
             yield return new XElement("DesiredZoom", DesiredZoom.ToString(CultureInfo.InvariantCulture));
             yield return new XElement("DesiredFov", DesiredFov.ToString(CultureInfo.InvariantCulture));
             yield return new XElement("OffsetUpdateLocation", OffsetUpdateLocation);


### PR DESCRIPTION
## Proposed Changes

- Auto quit feature
   - A new checkbox is added to the 'Processes' form that allows FFXIV Zoom Hack to close itself after the last FFXIV client is closed. This is off by default.
   - A tooltip is added to explain this behavior beyond 'Quit when processes close'

- Alignment of "default URL" and "update offset" boxes is now set to one another (this one doesn't really matter, it was more something I did while learning about Windows Forms.)

This is the first time I've ever worked with C# or Windows Forms. Please let me know if there's anything I should be aware of!

![image](https://user-images.githubusercontent.com/696702/73022730-fe7f2180-3dde-11ea-9bfa-37fedc254dde.png)
